### PR TITLE
revisão do cookbook

### DIFF
--- a/04-cookbook/cookbook.lua
+++ b/04-cookbook/cookbook.lua
@@ -127,4 +127,4 @@ frequencies()
 sort()
 print_words()
 
-
+-- ver comentarios no pull-request(roxana)


### PR DESCRIPTION
em geral o codigo segue o estilo cookbook, mas o codigo deve ter algumas issues pois o resultado não é correto.
![nino-eduardo-cookbook](https://user-images.githubusercontent.com/1106435/27539271-b203c80e-5a30-11e7-826a-ec40edfcbe6f.png)

tenho uma duvida sobre as linhas 54-57, onde se faz a conta do numero de palavras que existem na tabela words. Di uma busca nas funções de Lua, e achei que é possivel fazer essa conta só com o operador #, mas a tabela tem que ser de tipo array-table. Vocês fizeram uso de esse operador no estilo monolithic, porque aqui não foi utilizado?

No código não tem se a regra 2 da [disciplina](https://pes2006.wordpress.com/2006/03/15/disciplina/):
_Sempre que descrever algo em documentos, deve-se atentar para o uso de pré e pós-condições, e argumentação. É a maneira disciplinada para garantir que o que escreveu segue aquilo que tinha em mente antes de escrever._ 
