### PR TITLE
revisão do pipeline

### DIFF
--- a/05-pipeline/pipeline.lua
+++ b/05-pipeline/pipeline.lua
@@ -126,3 +126,4 @@ end
 -- The main function
 --
 print_words(sort(frequencies(remove_stop_words(scan(filter_chars_and_normalize(read_file(arg[1])))))))
+-- ver comentarios no pull-request (Roxana)


### PR DESCRIPTION
O código não mostra os resultados corretamente.
![nino-eduardo-pipeline](https://user-images.githubusercontent.com/1106435/27541590-559a5e94-5a39-11e7-9bab-85952d1be662.png)

Em geral os modulos seguem a forma do estilo, mas tenho apenas uma observação:
Nas linhas 58-77: argumentar o uso de indexes para este estilo. No estilo cookbook foi necessario, aqui porque?

No código não tem se a regra 2 da [disciplina](https://pes2006.wordpress.com/2006/03/15/disciplina/):
_Sempre que descrever algo em documentos, deve-se atentar para o uso de pré e pós-condições, e argumentação. É a maneira disciplinada para garantir que o que escreveu segue aquilo que tinha em mente antes de escrever._ 
