### PR TITLE
revisão do letterbox

### DIFF
--- a/11-letterbox/Letterbox.lua
+++ b/11-letterbox/Letterbox.lua
@@ -296,3 +296,5 @@ end
 wfcontroller = WordFrequencyController
 wfcontroller:dispatchMessage({"initiate_all", arg[1]})
 wfcontroller:dispatchMessage({"execute"})
+
+-- ver comentarios no pull-request (Roxana)


### PR DESCRIPTION
O código segue a forma do estilo.
apenas uma observação. O codigo não mostra os resultados corretamente.
![nino-letterbox](https://user-images.githubusercontent.com/1106435/27543330-cb693f50-5a3e-11e7-9675-950291023724.png)
